### PR TITLE
[FIXED JENKINS-17041] fix link to subview in nested view set as default view

### DIFF
--- a/src/main/java/hudson/plugins/nested_view/NestedView.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedView.java
@@ -78,6 +78,11 @@ public class NestedView extends View implements ViewGroup, StaplerProxy {
     }
 
     @Override
+    public String getUrl() {
+        return getViewUrl();
+    }
+
+    @Override
     public View getPrimaryView() {
         return null;
     }


### PR DESCRIPTION
Override getUrl() and forces to include nested view path.
It also fixes link to subview's configure page in sidepanel.
