### PR TITLE
[FIXES JENKINS-20616] replace target only if default view is set

### DIFF
--- a/src/main/java/hudson/plugins/nested_view/NestedView.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedView.java
@@ -445,7 +445,8 @@ public class NestedView extends View implements ViewGroup, StaplerProxy {
 
     public Object getTarget() {
         // Proxy to handle redirect when a default subview is configured
-        return "".equals(Stapler.getCurrentRequest().getRestOfPath())
+        return (getDefaultView() != null &&
+                "".equals(Stapler.getCurrentRequest().getRestOfPath()))
                 ? new DefaultViewProxy() : this;
     }
 


### PR DESCRIPTION
then nested view can appear at the end of breadcrumb list
it fixes https://issues.jenkins-ci.org/browse/JENKINS-20616
