### PR TITLE
Fix ampersand escaping in output of nbspIndent.

### DIFF
--- a/src/main/resources/hudson/plugins/nested_view/NestedView/main.jelly
+++ b/src/main/resources/hudson/plugins/nested_view/NestedView/main.jelly
@@ -50,10 +50,10 @@ THE SOFTWARE.
           <tr style="border-top:0">
             <th width="1"></th>
             <j:if test="${optionalColumns.showStatusColumn}">
-              <th width="1" tooltip="${%StatusTooltip}">${h.nbspIndent(iconSize)}S</th>
+              <th width="1" tooltip="${%StatusTooltip}"><j:out value="${h.nbspIndent(iconSize)}"/>S</th>
             </j:if>
             <j:if test="${optionalColumns.showWeatherColumn}">
-              <th width="1" tooltip="${%WeatherTooltip}">${h.nbspIndent(iconSize)}W</th>
+              <th width="1" tooltip="${%WeatherTooltip}"><j:out value="${h.nbspIndent(iconSize)}"/>W</th>
             </j:if>
             <th width="*">${%View}</th>
           </tr>


### PR DESCRIPTION
This fixes a problem where when you have a Nested "All" / default view the table header outputs &nbsp;&nbsp... as text. This is due to Jelly escaping HTML resulting in the source code: &amp;nbsp;... 

This only seems to render weird on Firefox (I suspect that the browsers (chrome etc...) detect and render the HTML).

This is detailed here: https://wiki.jenkins-ci.org/display/JENKINS/Jelly+and+XSS+prevention