### PR TITLE
[JENKINS-59466] Fixing the error for Nested View when loading for CasC

### DIFF
--- a/src/main/java/hudson/plugins/nested_view/NestedView.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedView.java
@@ -53,6 +53,7 @@ import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import hudson.views.ListViewColumn;
 import hudson.views.ViewsTabBar;
+import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithContextMenu;
 import org.apache.commons.jelly.JellyException;
 import org.kohsuke.stapler.*;
@@ -255,7 +256,13 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
     }
 
     public void save() throws IOException {
-        owner.save();
+        if (owner != null) {
+            owner.save();
+        }
+        else{
+            setOwner(Jenkins.getInstance());
+            owner.save();
+        }
     }
 
     public void doCreateView(StaplerRequest req, StaplerResponse rsp)

--- a/src/test/java/hudson/plugins/nested_view/NestedViewTest.java
+++ b/src/test/java/hudson/plugins/nested_view/NestedViewTest.java
@@ -243,4 +243,18 @@ public class NestedViewTest {
         project.renameTo("project-renamed");
         assertTrue("Subview contains renamed item.", subview.contains(project));
     }
+
+    @Issue("JENKINS-59466")
+    @Test
+    public void testSetViewNoOwner() throws IOException{
+        FreeStyleProject project = rule.createFreeStyleProject("project");
+        NestedView view = new NestedView("nested");
+        //This should add a view owned by the Jenkins user since there is "no owner"
+        rule.jenkins.addView(view);
+        assertEquals("Jenkins", view.getOwner().getDisplayName());
+        ListView subview = new ListView("listView", view);
+        view.addView(subview);
+        subview.add(project);
+        assertTrue("Subview 'listView' should contains item 'project'", subview.contains(project));
+    }
 }


### PR DESCRIPTION
When loading a configuration with Config as Code and having nested views, the owner does not exist so I force the owner to be "Jenkins" if the owner is currently null which fixes the error loading a yaml for Config as Code