### PR TITLE
fix search result urls when jenkins runs with a prefix

### DIFF
--- a/src/main/java/hudson/plugins/nested_view/NestedViewsSearch.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedViewsSearch.java
@@ -148,10 +148,14 @@ public class NestedViewsSearch extends Search {
         }
 
         public String getUrl() {
+            String rootUrl = Jenkins.get().getRootUrl();
+            if(rootUrl.endsWith("/")){
+                rootUrl = rootUrl.substring(0, rootUrl.length()-1);
+            }
             if (item instanceof FreeStyleProject) {
-                return "../../../../../../../../../../../../../../job/" + name;
+                return rootUrl + "/job/" + name;
             } else {
-                return "../../../../../../../../../../../../../../" + getFullPath().replace("/", "/view/");
+                return rootUrl + getFullPath().replace("/", "/view/");
             }
         }
 


### PR DESCRIPTION
The search engine doesn't return correct urls, leading to 404 errors when jenkins is running with a prefix (`--prefix` option)
This PR intends to ensure the urls associated with search results contain jenkins's prefix.

What I did :
* Create a new test (`NestedViewTest.testSearchWithPrefix()`) which intends to ensure search results urls contain jenkins prefix when searching for jobs, view and nested views. Then check test fails without the fix.
* Modify `NestedViewsSearch.getUrl()` to use `Jenkins.get().getRootUrl()` as the beginning of each search result url.
* Checked the test doesn't fail anymore and installed the plugin on a test jenkins instance to ensure the behavior is as desired.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
