### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/nested_view/NestedViewsSearch/search-results.jelly
+++ b/src/main/resources/hudson/plugins/nested_view/NestedViewsSearch/search-results.jelly
@@ -5,7 +5,7 @@
     <!-- needed for printing title. -->
     <l:layout title="${%Search for} '${q}'">
         <l:side-panel>
-            <h2><img src="${rootURL}/images/16x16/help.png" /> Search help</h2>
+            <h2><l:icon class="icon-help icon-sm" /> Search help</h2>
             <h3>${%Supported keywords with an example}</h3>
             <ol>
                  <j:forEach var="help" items="${it.getSearchHelp()}">


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
In case of your plugin, I've removed the header icons, because that is what modern Jenkins does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @judovana 
Thanks in advance!