### PR TITLE
Use `XStream2` where possible

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,16 @@
     <relativePath />
   </parent>
   <properties>
+    <revision>1.33</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.361</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
   <artifactId>nested-view</artifactId>
   <packaging>hpi</packaging>
   <name>Nested View Plugin</name>
-  <version>1.33-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <url>https://wiki.jenkins.io/display/JENKINS/Nested+View+Plugin</url>
 
   <developers>
@@ -24,10 +27,10 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/nested-view-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/nested-view-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/nested-view-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
 
   <repositories>

--- a/src/main/java/hudson/plugins/nested_view/NestedView.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedView.java
@@ -26,7 +26,6 @@ package hudson.plugins.nested_view;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.StreamException;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.util.IOException2;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -41,7 +40,6 @@ import java.io.StringWriter;
 import hudson.util.XStream2;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.transform.Source;
-import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -522,7 +520,7 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
             XStream2 xstream = new XStream2();
             //Owner of this view does not have to be changed
             xstream.registerLocalConverter(View.class, "owner", new OwnerConvertor());
-            xstream.unmarshal(new XppDriver().createReader(in), this);
+            xstream.unmarshal(XStream2.getDefaultDriver().createReader(in), this);
         } catch (StreamException e) {
             throw new IOException2("Unable to read",e);
         } catch(ConversionException e) {
@@ -619,7 +617,7 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
 
         @Override
         public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
-            XStream stream = new XStream();
+            XStream2 stream = new XStream2();
             if(source.equals(owner)){
                 writer.addAttribute("ignore", "true");
                 return;
@@ -633,7 +631,7 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
             if(reader.getAttribute("ignore")!=null && reader.getAttribute("ignore").equals("true")){
                 return owner;
             }
-            XStream stream = new XStream();
+            XStream2 stream = new XStream2();
             Object o = stream.unmarshal(reader);
             return o;
         }


### PR DESCRIPTION
This plugin was inconsistently using a mixture of `XStream` and `XStream2`. Jenkins core defines `XStream2` as a subclass of `XStream` with various Jenkins-specific customizations, so this PR fixes up remaining usages to be consistent with Jenkins core.

### Testing done

I ran `mvn clean verify` with these changes.