### PR TITLE
Migrate documentation from wiki to GitHub and copyedit README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Change Log
+
+### Version 1.14 (November 23, 2013)
+
+- Improve breadcrumb list behavior ([JENKINS-19698](https://issues.jenkins.io/browse/JENKINS-19698),[JENKINS-20616](https://issues.jenkins.io/browse/JENKINS-20616))
+
+### Version 1.13 (November 5, 2013)
+
+- Fixed view results to be gray if no jobs were run in subviews yet ([issue \#17040](https://issues.jenkins.io/browse/JENKINS-17040))
+- Fixed deleting of subviews (it didn't save on disk) ([issue \#20382](https://issues.jenkins.io/browse/JENKINS-20382))
+
+### Version 1.12 (October 30, 2013)
+
+- Fixed view results (aggregating of subviews and jobs) to follow the correct priority - if at least one job is red, then the view will be red ([issue \#19716](https://issues.jenkins.io/browse/JENKINS-19716))
+
+### Version 1.11 (September 25, 2013)
+
+- Fixed creation of subviews if Nested View is the default one ([JENKINS-17041](https://issues.jenkins.io/browse/JENKINS-17041))
+- Support checking duplicate names with Jenkins 1.512 or newer ([JENKINS-18053](https://issues.jenkins.io/browse/JENKINS-18053))
+
+### Version 1.10 (April 7, 2013)
+
+- Added an ability to remove or add Weather and Status columns which speeds up nested views ([JENKINS-17352](https://issues.jenkins.io/browse/JENKINS-17352))
+
+### Version 1.9 (August 16, 2012)
+
+- Improved performance and accuracy when computing worst result and health for large views
+- add support for hierarchical job model (ex : cloudbees folder plugin)
+- display grey icon when no nested content has been built
+
+### Version 1.8 (Jul 28, 2011)
+
+- Properly check for duplicate names within the current nested view when creating a new view (in Jenkins 1.416 or newer).
+- Ignore disabled project when calculating worst build result in a nested view. ([JENKINS-8922](https://issues.jenkins.io/browse/JENKINS-8922))
+
+### Version 1.7 (Feb 25, 2011)
+
+- Rerelease 1.6 to properly set required Jenkins version.
+
+### Version 1.6 (Feb 16, 2011)
+
+- Show status icon for each view, representing the worst result of any job in that view. ([JENKINS-7124](https://issues.jenkins.io/browse/JENKINS-7124))
+- Fix link in empty nested view to be a link instead of raw HTML. ([JENKINS-7862](https://issues.jenkins.io/browse/JENKINS-7862))
+
+### Version 1.5 (Oct 20, 2010)
+
+- Update to work with Hudson 1.381 or higher. ([JENKINS-7815](https://issues.jenkins.io/browse/JENKINS-7815))
+- Calculate view-health for a nested view by recursing into its subviews. ([JENKINS-7125](https://issues.jenkins.io/browse/JENKINS-7125))
+- Export nested view details via Remote API. ([JENKINS-7489](https://issues.jenkins.io/browse/JENKINS-7489))
+- Don't allow setting a default subview for a nested view that is the Hudson default view, as this prevents access to other top level view tabs. ([JENKINS-7362](https://issues.jenkins.io/browse/JENKINS-7362))
+
+### Version 1.4 (Jul 12, 2010)
+
+- Update to work with Hudson 1.366 or higher.
+
+### Version 1.3 (Jun 16, 2010)
+
+- Sort subviews alphabetically. ([JENKINS-6757](https://issues.jenkins.io/browse/JENKINS-6757))
+- Russian translation.
+
+### Version 1.2 (May 27, 2010)
+
+- Add weather icons in nested view. ([JENKINS-6235](https://issues.jenkins.io/browse/JENKINS-6235))
+
+### Version 1.1 (Mar 22, 2010)
+
+- Spanish translation.
+
+### Version 1.0 (Jan 21, 2010)
+
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,32 @@
-# jenkins nested-view-plugin
+# Nested View
 
-An awesome legacy extension for jenkins - no pipelines, no folders, thousands of jobs with ten thousands of views? This can help you to make an order!
+A view type to allow grouping job views into multiple levels instead of one big list of tabs.
+This is an awesome legacy extension for Jenkins.
+No pipelines, no folders, thousands of jobs with ten thousands of views?
+This can help you to make an order!
+
+## Introduction
+
+This plugin adds a new view type that can be selected when adding job views.
+This view does not show any jobs, but rather contains another set of views.
+By default, clicking on the view tab for a nested view shows a list of the subviews it contains (with folder icons).
+You can also configure a default subview to bypass this intermediate page and jump directly to that default view.
+Now the view tabs across the top show the views in this nested view, and the job list is for this default subview.
+This streamlines the navigation between views, but makes it harder to find the *Edit View* link for the nested view itself.
+Once a default subview has been assigned, navigate to the edit page by first clicking the plus ("+") icon in the view tabs (for adding a new subview) and then find the *Edit View* link in the sidepanel.
 
 ## Search extension
-NestedViews had long ago bug, that search was unable to crawl inside nested views. To fix that, lead to the overriding of serch engine.
-Deatails about search impl can be found: https://jvanek.fedorapeople.org/jenkinsSearch/
 
-The search have its pros and cons. It can be enabled/disbaled in global settings, or temorarily by `-X:` in query.
+A long time ago, Nested View had a bug where search was unable to crawl inside nested views.
+Fixing that led to overriding the search engine.
+Details about the search implementation can be found here: https://jvanek.fedorapeople.org/JenkinsSearch/
 
-The search knows logical operators and can search also in builds via displayName and comment and hsowinf build details and statistics, and have customizable saving of search history. Unluckily, can not search in settings or have undocumented issues in pipelines environemnt.
+The search has its pros and cons.
+It can be enabled/disabled in global settings or temorarily by appending `-X:` to the query.
+
+The search knows logical operators and can search also in builds via display name/comment and showing build details and statistics.
+This plugin supports customizable saving of search history.
+Unfortunately, you cannot search in settings or have undocumented issues in your Pipeline job's environment.
 
 ## Testing build
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <packaging>hpi</packaging>
   <name>Nested View Plugin</name>
   <version>${revision}${changelist}</version>
-  <url>https://wiki.jenkins.io/display/JENKINS/Nested+View+Plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <developers>
     <developer>


### PR DESCRIPTION
While working on this plugin recently, I noticed it had never been migrated from the old (now frozen) Confluence wiki to GitHub. I did the migration, and then when I was done I copyedited the result. I also edited `pom.xml` so that the next release on https://plugins.jenkins.io/nested-view will show the documentation from the `README` rather than the frozen wiki export.