### PR TITLE
Enabling access to original search before comand pallete was introduced

### DIFF
--- a/src/main/java/hudson/plugins/nested_view/NestedViewLegacySearchGate.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedViewLegacySearchGate.java
@@ -1,0 +1,21 @@
+package hudson.plugins.nested_view;
+
+import hudson.Extension;
+import hudson.model.RootAction;
+
+@Extension
+public class NestedViewLegacySearchGate implements RootAction {
+
+    public String getIconFileName() {
+        return "clipboard.png";
+    }
+
+    public String getDisplayName() {
+        return "Nested view search gate";
+    }
+
+    public String getUrlName() {
+        return "nwSearchGate";
+    }
+
+}

--- a/src/main/resources/hudson/plugins/nested_view/NestedViewLegacySearchGate/index.jelly
+++ b/src/main/resources/hudson/plugins/nested_view/NestedViewLegacySearchGate/index.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+    <l:layout title="${it.run} ${it.displayName}">
+        <l:main-panel>
+                    <h3>Legacy search, which can be overwritten by nested-view in settings page</h3>
+                    <form action="/search/">
+                        <input type="text" id="q" name="q" value="" size="100" /><br/>
+                        <input type="submit" value="Search"/>
+                    </form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/nested_view/NestedViewsSearch/search-results.jelly
+++ b/src/main/resources/hudson/plugins/nested_view/NestedViewsSearch/search-results.jelly
@@ -32,6 +32,10 @@
         </l:side-panel>
         <l:main-panel>
             <j:set var="hits" value="${it.hits}"/>
+            <form action="/search/">
+                <input type="text" id="q" name="q" value="${q}" size="100" /><br/>
+                <input type="submit" value="Search"/>
+            </form>
             <h1>${%Search for} '${q}' returned: ${hits.size()}</h1>
             <ol>
                             <j:forEach var="hit" items="${hits}"> <!-- NestedViewsSearch.NestedViewsSearchResult -->


### PR DESCRIPTION
Added link to main menu, which opens the input form field, which the goes to /search/?q=... and thus providing original search capabilities.

If the nested-view-search extension is enbaled, this field is present also on main result page and thus allows super quick changes in search. I do not know how to do similar feature for legacysearch without nested-view-search extension