### PR TITLE
Removed double >> and pointed search to correctg url

### DIFF
--- a/src/main/resources/hudson/plugins/nested_view/NestedViewLegacySearchGate/index.jelly
+++ b/src/main/resources/hudson/plugins/nested_view/NestedViewLegacySearchGate/index.jelly
@@ -3,7 +3,7 @@
     <l:layout title="${it.run} ${it.displayName}">
         <l:main-panel>
             <h3>Legacy search, which can be overwritten by nested-view in settings page</h3>
-                <form action="/search/" method="get">
+                <form action="${h.searchURL}" method="get">
                     <f:entry>
                         <f:textbox name="q" />  
                     </f:entry>

--- a/src/main/resources/hudson/plugins/nested_view/NestedViewsSearch/search-results.jelly
+++ b/src/main/resources/hudson/plugins/nested_view/NestedViewsSearch/search-results.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <j:set var="q" value="${request2.getParameter('q')}"/>
     <j:new var="h" className="hudson.Functions"/>
     <!-- needed for printing title. -->
@@ -32,7 +32,7 @@
         </l:side-panel>
         <l:main-panel>
             <j:set var="hits" value="${it.hits}"/>
-            <form action="/search/" method="get">
+            <form action="${h.searchURL}" method="get">
                 <f:entry>
                     <f:textbox name="q" value="${q}" />
                 </f:entry>


### PR DESCRIPTION
the >> typo instead of > was breaking ui
the /search/ was incorrect when launched from else where then root, where eg hpi:run was making the to easy to hit. Fixed by ${h.searchURL}
