### PR TITLE
Prepare for Java 25 - Sep 16, 2025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.2</version>
+    <version>5.18</version>
     <relativePath />
   </parent>
   <properties>

--- a/src/main/java/hudson/plugins/nested_view/NestedViewsSearch.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedViewsSearch.java
@@ -117,13 +117,11 @@ public class NestedViewsSearch extends Search {
         v.forward(req, rsp);
     }
 
-    @SuppressFBWarnings(value = {"ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"}, justification = "history is shared")
     private void putToHistory(String query, int size, Date date) {
         HistoryItem his = new HistoryItem(query.trim().replaceAll("\\s+", " "), size, date);
         HistoryItem.add(his);
     }
 
-    @SuppressFBWarnings(value = {"ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"}, justification = "history is shared")
     public List getHistory() {
         return HistoryItem.get();
     }

--- a/src/main/java/hudson/plugins/nested_view/NestedViewsSearchFactory.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedViewsSearchFactory.java
@@ -30,7 +30,6 @@ public class NestedViewsSearchFactory extends SearchFactory {
     }
 
     @Override
-    @SuppressFBWarnings(value = {"ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"}, justification = "Well if several users searches in prallel this would be evil")
     public Search createFor(final SearchableModelObject owner) {
         if (NestedViewGlobalConfig.getInstance().isNestedViewSearch()) {
             if (isTmpSkip()) {

--- a/src/main/java/hudson/plugins/nested_view/search/BuildDetails.java
+++ b/src/main/java/hudson/plugins/nested_view/search/BuildDetails.java
@@ -27,7 +27,6 @@ public class BuildDetails {
                 archives > 0 ? run.getArtifactsUpTo(archives) : new ArrayList<Run.Artifact>(0));
     }
 
-    @SuppressFBWarnings(value = {"EI_EXPOSE_REP2"}, justification = "date is not cared")
     public BuildDetails(String prefix, String id, String displayName, String description, Result result, String timeStampString, Date dateTime, List<Run.Artifact> list) {
         this.prefix = prefix;
         this.id = id;

--- a/src/main/java/hudson/plugins/nested_view/search/HistoryItem.java
+++ b/src/main/java/hudson/plugins/nested_view/search/HistoryItem.java
@@ -29,7 +29,6 @@ public class HistoryItem {
     private final int size;
     private final Date date;
 
-    @SuppressFBWarnings(value = {"EI_EXPOSE_REP2"}, justification = "date is not cared")
     public HistoryItem(String query, int size, Date date) {
         this.query = query;
         this.size = size;


### PR DESCRIPTION
## Prepare for Java 25 - Sep 16, 2025

The Jenkins project strives to support new Java LTS releases soon after they are generally available.  Java 25 is scheduled to release Sep 16, 2025.  We'd like Jenkins core and the top 250 plugins to compile and test with Java 25 by Oct 31, 2025.

This change allows the plugin to compile and test successfully with Java 24 as a step towards supporting Java 25.  

Since we expect Java 25 to be a superset of Java 24, it is a step forward to allow the plugin to compile and test with Java 24, even though Jenkins does not support Java 24.

Supersedes pull request:

* https://github.com/jenkinsci/nested-view-plugin/pull/62

### Testing done

Confirmed that `mvn clean verify` passes with Java 24.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
