### PR TITLE
Prepare for Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.18</version>
+    <version>5.24</version>
     <relativePath />
   </parent>
   <properties>

--- a/src/main/java/hudson/plugins/nested_view/NestedView.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedView.java
@@ -162,8 +162,8 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
     public Item doCreateItem(StaplerRequest2 req, StaplerResponse2 rsp)
             throws IOException, ServletException {
         ItemGroup itemGroup = getItemGroup();
-        if (itemGroup instanceof ModifiableItemGroup) {
-            return ((ModifiableItemGroup) itemGroup).doCreateItem(req, rsp);
+        if (itemGroup instanceof ModifiableItemGroup group) {
+            return group.doCreateItem(req, rsp);
         }
         return null;
     }
@@ -316,8 +316,8 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
         List<NestedView> nestedViews = new ArrayList<NestedView>();
 
         for (View v : views) {
-            if (v instanceof NestedView) {
-                nestedViews.add((NestedView) v);
+            if (v instanceof NestedView view) {
+                nestedViews.add(view);
             } else {
                 normalViews.add(v);
             }
@@ -391,9 +391,9 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
         boolean found = false;
         Result result = Result.NOT_BUILT, check;
         for (TopLevelItem item : v.getItems()) {
-            if (item instanceof Job && !(  // Skip disabled projects
-                    item instanceof AbstractProject && ((AbstractProject) item).isDisabled())) {
-                final Run lastCompletedBuild = ((Job) item).getLastCompletedBuild();
+            if (item instanceof Job job && !(  // Skip disabled projects
+                    item instanceof AbstractProject project && project.isDisabled())) {
+                final Run lastCompletedBuild = job.getLastCompletedBuild();
                 if (lastCompletedBuild != null) {
                     found = true;
                     check = lastCompletedBuild.getResult();
@@ -420,8 +420,8 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
      * @see #getWorstResultForNormalView(hudson.model.View)
      */
     public static Result getWorstResult(View v) {
-        if (v instanceof NestedView) {
-            return ((NestedView) v).getWorstResult();
+        if (v instanceof NestedView view) {
+            return view.getWorstResult();
         } else {
             return getWorstResultForNormalView(v);
         }
@@ -443,8 +443,8 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
         viewsStack.push(this);
         do {
             View currentView = viewsStack.pop();
-            if (currentView instanceof NestedView) {
-                for (View v : ((NestedView) currentView).views) {
+            if (currentView instanceof NestedView view) {
+                for (View v : view.views) {
                     viewsStack.push(v);
                 }
             } else {
@@ -454,8 +454,8 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
 
         HealthReportContainer hrc = new HealthReportContainer();
         for (TopLevelItem item : items) {
-            if (item instanceof Job) {
-                hrc.sum += ((Job) item).getBuildHealth().getScore();
+            if (item instanceof Job job) {
+                hrc.sum += job.getBuildHealth().getScore();
                 hrc.count++;
             }
         }
@@ -539,8 +539,7 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
     private static HealthReportContainer getHealthForNormalView(View view) {
         HealthReportContainer hrc = new HealthReportContainer();
         for (TopLevelItem item : view.getItems()) {
-            if (item instanceof Job) {
-                Job job = (Job) item;
+            if (item instanceof Job job) {
                 if (job.getBuildHealthReports().isEmpty()) continue;
                 hrc.sum += job.getBuildHealth().getScore();
                 hrc.count++;
@@ -559,8 +558,8 @@ public class NestedView extends View implements ViewGroup, StaplerProxy, ModelOb
      * @see #getHealthForNormalView(hudson.model.View)
      */
     public static HealthReportContainer getViewHealth(View v) {
-        if (v instanceof NestedView) {
-            return ((NestedView) v).getHealth();
+        if (v instanceof NestedView view) {
+            return view.getHealth();
         } else {
             return getHealthForNormalView(v);
         }

--- a/src/main/java/hudson/plugins/nested_view/NestedViewsSearch.java
+++ b/src/main/java/hudson/plugins/nested_view/NestedViewsSearch.java
@@ -53,8 +53,8 @@ public class NestedViewsSearch extends Search {
             List<NamableWithClass> all = new ArrayList(1000);
             Jenkins j = Jenkins.get();
             for (TopLevelItem ti : j.getItems()) {
-                if (ti instanceof AbstractProject) {
-                    all.add(new NamableWithClass(ti, ti.getName(), ti.getName(), ((AbstractProject<?, ?>) ti).getDescription()));
+                if (ti instanceof AbstractProject<?, ?> project) {
+                    all.add(new NamableWithClass(ti, ti.getName(), ti.getName(), project.getDescription()));
                 }
             }
             addViewsRecursively(j.getViews(), "/", all);
@@ -64,10 +64,9 @@ public class NestedViewsSearch extends Search {
 
     private void addViewsRecursively(Collection<View> views, String s, List<NamableWithClass> all) {
         for (View v : views) {
-            if (v instanceof NestedView) {
-                NestedView nw = (NestedView) v;
+            if (v instanceof NestedView nw) {
                 all.add(new NamableWithClass(v, v.getViewName(), s + v.getViewName(),  nw.getDescription()));
-                addViewsRecursively(((NestedView) v).getViews(), s + v.getViewName() + "/", all);
+                addViewsRecursively(nw.getViews(), s + v.getViewName() + "/", all);
             } else {
                 all.add(new NamableWithClass(v, v.getViewName(), s + v.getViewName(), v.getDescription()));
             }

--- a/src/main/java/hudson/plugins/nested_view/search/NamableWithClass.java
+++ b/src/main/java/hudson/plugins/nested_view/search/NamableWithClass.java
@@ -143,8 +143,8 @@ public class NamableWithClass {
     }
 
     public Optional<AbstractProject> getProject() {
-        if (item instanceof AbstractProject) {
-            return Optional.of((AbstractProject) item);
+        if (item instanceof AbstractProject project) {
+            return Optional.of(project);
         } else {
             return Optional.empty();
         }

--- a/src/main/java/hudson/plugins/nested_view/search/ProjectWrapper.java
+++ b/src/main/java/hudson/plugins/nested_view/search/ProjectWrapper.java
@@ -155,8 +155,7 @@ public class ProjectWrapper {
                         break;
                     }
                     Object q = it.next();
-                    if (q instanceof AbstractBuild) {
-                        AbstractBuild b = (AbstractBuild) q;
+                    if (q instanceof AbstractBuild b) {
                         if (i1 > 0) {
                             if (query != null && (query.isSearchByNvr() >= 0 || query.isSearchByBuildComment()>=0)) {
                                 for (String candidate : query.getWithoutArgumentsSplit()) {


### PR DESCRIPTION
## Prepare for Java 25

Use parent pom 5.24 so we can compile with Java 25

Java 25 will release Sep 16, 2025.  Jenkins wants to support it soon after release by compiling and testing Jenkins core and Jenkins plugins.  This change allows the plugin to compile with Java 25.  Tests fail because the javassist byte code library needs to be updated for Java 25 byte code.

If the javassist byte code library does not update to support Java 25 byte code, then the code can be switched to use bytebuddy, since bytebuddy already supports Java 25 byte code.

Simplify code with pattern matching instanceof

Java 17 allows instanceof to define a variable of the type matching the instanceof.  That can simplify later code.  Since the plugin already requires Jenkins 2.479 or newer, it is safe to use a Java 17 language feature.

### Testing done

Confirmed that code compiles and passes tests with Java 21 and that code compiles with Java 25.  Tests fail because the javaassist byte code library does not support Java 25 byte code

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
